### PR TITLE
goosedb: add programmatic DBConf constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ You may include as many environments as you like, and you can use the `-env` com
 
 goose will expand environment variables in the `open` element. For an example, see the Heroku section below.
 
+If you are driving migrations from Go code and already have a DSN in memory,
+use `goosedb.NewConfig` or `goosedb.NewConfigCustom` to build a `*goosedb.DBConf`
+without creating a `dbconf.yml` file on disk.
+
 ## Database Drivers
 
 Currently, available dialects are: "postgres", "mysql", or "sqlite3".

--- a/lib/goosedb/dbconf_test.go
+++ b/lib/goosedb/dbconf_test.go
@@ -1,10 +1,64 @@
 package goosedb
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
+
+func TestNewConfig(t *testing.T) {
+	dbconf, err := NewConfig("postgres", "user=liam dbname=tester sslmode=disable", "sql/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := []string{dbconf.MigrationsDir, dbconf.Env, dbconf.Driver.Name, dbconf.Driver.OpenStr}
+	want := []string{"sql/migrations", "production", "postgres", "user=liam dbname=tester sslmode=disable"}
+
+	for i, s := range got {
+		if s != want[i] {
+			t.Errorf("Unexpected DBConf value. got %v, want %v", s, want[i])
+		}
+	}
+
+	if reflect.TypeOf(dbconf.Driver.Dialect) != reflect.TypeFor[*PostgresDialect]() {
+		t.Errorf("Unexpected dialect type: got %T", dbconf.Driver.Dialect)
+	}
+}
+
+func TestNewConfigRejectsUnknownDriver(t *testing.T) {
+	_, err := NewConfig("oracle", "ignored", "sql/migrations")
+	if err == nil {
+		t.Fatal("expected error for invalid driver")
+	}
+}
+
+func TestNewConfigCustom(t *testing.T) {
+	driver := DBDriver{
+		Name:    "custom",
+		OpenStr: "dsn",
+		Import:  "github.com/example/customdriver",
+		Dialect: &Sqlite3Dialect{},
+	}
+
+	dbconf, err := NewConfigCustom(driver, "sql/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if dbconf.Env != "production" {
+		t.Errorf("Unexpected env: got %q want %q", dbconf.Env, "production")
+	}
+	if !reflect.DeepEqual(dbconf.Driver, driver) {
+		t.Errorf("Unexpected driver: got %#v want %#v", dbconf.Driver, driver)
+	}
+}
+
+func TestNewConfigCustomRejectsInvalidDriver(t *testing.T) {
+	_, err := NewConfigCustom(DBDriver{Name: "broken"}, "sql/migrations")
+	if err == nil {
+		t.Fatal("expected error for invalid custom driver")
+	}
+}
 
 func TestBasics(t *testing.T) {
 
@@ -38,14 +92,13 @@ func TestImportOverride(t *testing.T) {
 }
 
 func TestDriverSetFromEnvironmentVariable(t *testing.T) {
-
 	databaseUrlEnvVariableKey := "DB_DRIVER"
 	databaseUrlEnvVariableVal := "sqlite3"
 	databaseOpenStringKey := "DATABASE_URL"
 	databaseOpenStringVal := "db.db"
 
-	os.Setenv(databaseUrlEnvVariableKey, databaseUrlEnvVariableVal)
-	os.Setenv(databaseOpenStringKey, databaseOpenStringVal)
+	t.Setenv(databaseUrlEnvVariableKey, databaseUrlEnvVariableVal)
+	t.Setenv(databaseOpenStringKey, databaseOpenStringVal)
 
 	dbconf, err := NewDBConf("../../db-sample", "environment_variable_config", "")
 	if err != nil {

--- a/lib/goosedb/goosedb.go
+++ b/lib/goosedb/goosedb.go
@@ -25,6 +25,26 @@ type DBConf struct {
 	PgSchema      string
 }
 
+// NewConfig returns a DBConf for the given driver name, connection string, and
+// migrations directory without reading dbconf.yml from disk.
+func NewConfig(driverName, openStr, migrationsDir string) (*DBConf, error) {
+	return NewConfigCustom(newDBDriver(driverName, openStr), migrationsDir)
+}
+
+// NewConfigCustom returns a DBConf for callers that need to provide a fully
+// populated custom driver configuration.
+func NewConfigCustom(driver DBDriver, migrationsDir string) (*DBConf, error) {
+	if !driver.IsValid() {
+		return nil, fmt.Errorf("goose: invalid driver configuration: %v", driver)
+	}
+
+	return &DBConf{
+		MigrationsDir: migrationsDir,
+		Env:           "production",
+		Driver:        driver,
+	}, nil
+}
+
 // OpenDBFromDBConf wraps database/sql.DB.Open() and configures
 // the newly opened DB based on the given DBConf.
 //
@@ -78,16 +98,13 @@ func NewDBConf(p, env string, pgschema string) (*DBConf, error) {
 		d.Dialect = dialectByName(dialect)
 	}
 
-	if !d.IsValid() {
-		return nil, fmt.Errorf("goose: invalid driver configuration: %v", d)
+	conf, err := NewConfigCustom(d, filepath.Join(p, "migrations"))
+	if err != nil {
+		return nil, err
 	}
-
-	return &DBConf{
-		MigrationsDir: filepath.Join(p, "migrations"),
-		Env:           env,
-		Driver:        d,
-		PgSchema:      pgschema,
-	}, nil
+	conf.Env = env
+	conf.PgSchema = pgschema
+	return conf, nil
 }
 
 // Create a new DBDriver and populate driver specific


### PR DESCRIPTION
Add `NewConfig` and `NewConfigCustom` so callers can build a valid
`*goosedb.DBConf` without writing a `dbconf.yml` file first. This keeps
driver defaults and dialect selection inside the package instead of
forcing application code to duplicate the `newDBDriver` switch or wire
up dialect types directly.

Reuse the new constructor path from `NewDBConf` so YAML-backed configs
and programmatic configs share the same validation behavior. Add tests
for the new constructors and document the in-memory configuration path
in the README.

