### PR TITLE
goose: support stdout version output

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,7 @@ import (
 var flagPath = flag.String("path", "db", "folder containing db info")
 var flagEnv = flag.String("env", "development", "which DB environment to use")
 var flagPgSchema = flag.String("pgschema", "", "which postgres-schema to migrate (default = none)")
+var flagVersion = flag.Bool("version", false, "print goose version")
 
 // helper to create a DBConf from the given flags
 func dbConfFromFlags() (*goosedb.DBConf, error) {
@@ -95,13 +97,21 @@ func helpRun(*Command, ...string) {
 	flag.Usage()
 }
 
+func printVersion(w io.Writer) {
+	fmt.Fprintf(w, "%s\n", goose.Version)
+}
+
 func versionRun(*Command, ...string) {
-	fmt.Fprintf(os.Stderr, "goose version %s\n", goose.Version)
+	printVersion(os.Stdout)
 }
 
 func main() {
 	flag.Usage = usage
 	flag.Parse()
+	if *flagVersion {
+		printVersion(os.Stdout)
+		return
+	}
 
 	args := flag.Args()
 	if len(args) == 0 || args[0] == "-h" {

--- a/cmd/goose/main_test.go
+++ b/cmd/goose/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/kevinburke/goose/lib/goose"
+)
+
+func TestPrintVersion(t *testing.T) {
+	var buf bytes.Buffer
+	printVersion(&buf)
+	if got, want := buf.String(), goose.Version+"\n"; got != want {
+		t.Fatalf("printVersion() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Add a global --version flag so the CLI can print its version without a
subcommand, and route both version entry points through the same helper.

The version output now writes the plain version string to stdout instead
of stderr, which makes the command easier to script and matches the user
request. Add a focused test for the shared formatter so this behavior is
less likely to regress.

