### PR TITLE
cmd/goose: send unknown command errors to stderr

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -105,6 +105,10 @@ func versionRun(*Command, ...string) {
 	printVersion(os.Stdout)
 }
 
+func printUnknownCommand(w io.Writer, name string) {
+	fmt.Fprintf(w, "error: unknown command %q\n", name)
+}
+
 func main() {
 	flag.Usage = usage
 	flag.Parse()
@@ -129,7 +133,7 @@ func main() {
 	}
 
 	if cmd == nil {
-		fmt.Printf("error: unknown command %q\n", name)
+		printUnknownCommand(os.Stderr, name)
 		flag.Usage()
 		os.Exit(1)
 	}

--- a/cmd/goose/main_test.go
+++ b/cmd/goose/main_test.go
@@ -14,3 +14,11 @@ func TestPrintVersion(t *testing.T) {
 		t.Fatalf("printVersion() = %q, want %q", got, want)
 	}
 }
+
+func TestPrintUnknownCommand(t *testing.T) {
+	var buf bytes.Buffer
+	printUnknownCommand(&buf, "wat")
+	if got, want := buf.String(), "error: unknown command \"wat\"\n"; got != want {
+		t.Fatalf("printUnknownCommand() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Route the unknown-command error path through a small helper that writes
explicitly to stderr instead of stdout.

Add a unit test for the rendered message so this output stream behavior is
covered going forward.

